### PR TITLE
Adds `infra` Tag for tests requiring specific infrastructure

### DIFF
--- a/Sources/Utilities/Tag.swift
+++ b/Sources/Utilities/Tag.swift
@@ -9,6 +9,9 @@ import Testing
 
 extension Tag {
     public enum device {}
+
+    /// Test has specific infrastructure needs unlikely to be present outside of central CI
+    @Tag public static var infra: Tag
 }
 
 extension Tag.device {

--- a/Tests/SwiftAppiumTests/SwiftAppiumTest.swift
+++ b/Tests/SwiftAppiumTests/SwiftAppiumTest.swift
@@ -3,7 +3,18 @@ import SwiftAppium
 import Testing
 import Foundation
 
-@Suite("SwiftAppium Test", .tags(.device.browser.chrome), .serialized, .server("http://10.172.1.157:4723"), .exampleDevice(.chrome)) struct WebTest {
+@Suite(
+    "SwiftAppium Test",
+    .tags(
+        .device.browser.chrome,
+        .infra
+    ),
+    .serialized,
+    .server("http://10.172.1.157:4723"),
+    .exampleDevice(.chrome)
+)
+
+struct WebTest {
     @Test("[Feed] Sessions") func addTestSessionInFeed() async throws {
         try await Environment.test.navigate("https://www.milcgroup.com")
     }

--- a/Tests/SwiftAppiumTests/SwiftAppiumTest.swift
+++ b/Tests/SwiftAppiumTests/SwiftAppiumTest.swift
@@ -13,7 +13,6 @@ import Foundation
     .server("http://10.172.1.157:4723"),
     .exampleDevice(.chrome)
 )
-
 struct WebTest {
     @Test("[Feed] Sessions") func addTestSessionInFeed() async throws {
         try await Environment.test.navigate("https://www.milcgroup.com")


### PR DESCRIPTION
Also gets tests passing (in addition to [MR#13](https://github.com/MILCGroup/SwiftAppium/pull/13)) anywhere the infrastructure doesn't allow, by excluding this `.infra` Swift Testing Tag.